### PR TITLE
1087: Added InvalidNumberColor to Wpf.LinearColorAxis and added an ex…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Catmull-Rom spline interpolation algorithms (#494)
 - FontSize, FontWeight and FontFamily on Wpf.TextAnnotation (#1023)
 - RectangleSeries (#1060)
+- InvalidNumberColor on Wpf.LinearColorAxis (#1087)
 
 ### Changed
 - Let Gtk# PlotView show up in Ui editor ToolBox of MonoDevelop and XamarinStudio (#1071)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,6 +85,7 @@ Philippe AURIOU <p.auriou@live.fr>
 Piotr Warzocha <pw@piootr.pl>
 Rik Borger <isolocis@gmail.com>
 ryang <decatf@gmail.com>
+Sarah Müller <sy-mueller@gmx-topmail.de>
 Senen Fernandez <senenf@gmail.com>
 Shankar Mathiah Nanjundan <shankar.ooty@hotmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>

--- a/Source/Examples/WPF/WpfExamples/Examples/HeatMapDemo/MainWindow.xaml
+++ b/Source/Examples/WPF/WpfExamples/Examples/HeatMapDemo/MainWindow.xaml
@@ -3,25 +3,62 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:oxy="http://oxyplot.org/wpf"
         Title="HeatMapDemo" Height="480" Width="640">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-        <Slider Maximum="1.0" Minimum="0" x:Name="Slider" Value="0.5"/>
-        <oxy:Plot Grid.Row="1">
-            <oxy:Plot.Axes>
-                <oxy:LinearAxis Key="x" Position="Bottom"/>
-                <oxy:LinearAxis Key="y" Position="Left" />
-                <oxy:LinearColorAxis Key="z" Position="Top" LowColor="White" HighColor="Red" PaletteSize="100">
-                    <GradientStop Color="Aqua" Offset="0" />
-                    <GradientStop Color="Red" Offset="{Binding ElementName=Slider, Path=Value}" />
-                    <GradientStop Color="Black" Offset="1.0" />
-                </oxy:LinearColorAxis>
-            </oxy:Plot.Axes>
-            <oxy:Plot.Series>
-                <oxy:HeatMapSeries ColorAxisKey="Z" Data="{Binding Data}" X0="-1" X1="1" Y0="-1" Y1="1"/>
-            </oxy:Plot.Series>
-        </oxy:Plot>
-    </Grid>
+    <TabControl>
+        <TabItem Header="HeatMap">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Slider Maximum="1.0" Minimum="0" x:Name="Slider" Value="0.5"/>
+                <oxy:Plot Grid.Row="1">
+                    <oxy:Plot.Axes>
+                        <oxy:LinearAxis Key="x" Position="Bottom"/>
+                        <oxy:LinearAxis Key="y" Position="Left" />
+                        <oxy:LinearColorAxis Key="z" Position="Top" LowColor="White" HighColor="Red" PaletteSize="100">
+                            <GradientStop Color="Aqua" Offset="0" />
+                            <GradientStop Color="Red" Offset="{Binding ElementName=Slider, Path=Value}" />
+                            <GradientStop Color="Black" Offset="1.0" />
+                        </oxy:LinearColorAxis>
+                    </oxy:Plot.Axes>
+                    <oxy:Plot.Series>
+                        <oxy:HeatMapSeries ColorAxisKey="Z" Data="{Binding Data}" X0="-1" X1="1" Y0="-1" Y1="1"/>
+                    </oxy:Plot.Series>
+                </oxy:Plot>
+            </Grid>
+        </TabItem>
+        <TabItem Header="HeatMap With NaN Values">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Orientation="Horizontal">
+                <Label Content="Invalid Number Color: "/>
+                    <ComboBox  x:Name="Colors" Width="100">
+                        <ComboBoxItem Content="Blue"/>
+                        <ComboBoxItem Content="Gray"/>
+                        <ComboBoxItem Content="Green"/>
+                        <ComboBoxItem Content="Red"/>
+                        <ComboBoxItem Content="Transparent"/>
+                        <ComboBoxItem Content="Yellow"/>
+                    </ComboBox>
+                </StackPanel>
+                <oxy:Plot Grid.Row="1">
+                    <oxy:Plot.Axes>
+                        <oxy:LinearAxis Key="x" Position="Bottom"/>
+                        <oxy:LinearAxis Key="y" Position="Left" />
+                        <oxy:LinearColorAxis Key="z" Position="Top" LowColor="White" HighColor="Red" PaletteSize="100" InvalidNumberColor="{Binding ElementName=Colors, Path=SelectedItem.Content}">
+                            <GradientStop Color="Aqua" Offset="0" />
+                            <GradientStop Color="Red" Offset="0.5" />
+                            <GradientStop Color="Black" Offset="1.0" />
+                        </oxy:LinearColorAxis>
+                    </oxy:Plot.Axes>
+                    <oxy:Plot.Series>
+                        <oxy:HeatMapSeries ColorAxisKey="Z" Data="{Binding DataNaNValues}" X0="-1" X1="1" Y0="-1" Y1="1"/>
+                    </oxy:Plot.Series>
+                </oxy:Plot>
+            </Grid>
+        </TabItem>
+    </TabControl>
 </Window>

--- a/Source/Examples/WPF/WpfExamples/Examples/HeatMapDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/WpfExamples/Examples/HeatMapDemo/MainWindow.xaml.cs
@@ -10,7 +10,7 @@
 namespace HeatMapDemo
 {
     using System;
-
+    using System.Reflection;
     using WpfExamples;
 
     /// <summary>
@@ -27,6 +27,8 @@ namespace HeatMapDemo
             this.InitializeComponent();
             this.DataContext = this;
             this.Data = this.GenerateHeatMap();
+
+            this.DataNaNValues = this.GenerateHeatMapNaNValues();
         }
 
         /// <summary>
@@ -55,5 +57,33 @@ namespace HeatMapDemo
 
             return result;
         }
+
+        /// <summary>
+        /// Gets the data.
+        /// </summary>
+        public double[,] DataNaNValues { get; private set; }
+
+        /// <summary>
+        /// Generates the heat map data.
+        /// </summary>
+        /// <returns>
+        /// The heat map data array.
+        /// </returns>
+        private double[,] GenerateHeatMapNaNValues()
+        {
+            const int Rows = 100;
+            const int Cols = 100;
+            var result = new double[Rows, Cols];
+            for (var i = 0; i < Rows; i++)
+            {
+                for (var j = 0; j < Cols; j++)
+                {
+                    result[i, j] = (i==j)?double.NaN :Math.Sin(2 * Math.PI * i / Rows) * Math.Sin(2 * Math.PI * j / Cols);
+                }
+            }
+
+            return result;
+        }
+
     }
 }

--- a/Source/OxyPlot.Wpf/Axes/LinearColorAxis.cs
+++ b/Source/OxyPlot.Wpf/Axes/LinearColorAxis.cs
@@ -60,12 +60,37 @@ namespace OxyPlot.Wpf
             ValidatePaletteSize);
 
         /// <summary>
+        /// Identifies the <see cref="InvalidNumberColor"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty InvalidNumberColorProperty = DependencyProperty.Register(
+            "InvalidNumberColor",
+            typeof(Color),
+            typeof(LinearColorAxis),
+            new PropertyMetadata(Colors.Gray, AppearanceChanged));
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LinearColorAxis"/> class.
         /// </summary>
         public LinearColorAxis()
         {
             this.InternalAxis = new Axes.LinearColorAxis();
             this.GradientStops = new GradientStopCollection();
+        }
+
+        /// <summary>
+        /// Gets or sets the color used to represent NaN values.
+        /// </summary>
+        public Color InvalidNumberColor
+        {
+            get
+            {
+                return (Color)this.GetValue(InvalidNumberColorProperty);
+            }
+
+            set
+            {
+                this.SetValue(InvalidNumberColorProperty, value);
+            }
         }
 
         /// <summary>
@@ -161,6 +186,7 @@ namespace OxyPlot.Wpf
 
             axis.HighColor = this.HighColor.ToOxyColor();
             axis.LowColor = this.LowColor.ToOxyColor();
+            axis.InvalidNumberColor = this.InvalidNumberColor.ToOxyColor();
             axis.Minimum = this.Minimum;
             axis.Maximum = this.Maximum;
         }


### PR DESCRIPTION
…ample for binding to InvalidNumberColor (#1089)

removed xml documentationFiles

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-

@oxyplot/admins
